### PR TITLE
Add Prometheia MVP app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# Promethia-MVP-20250609
+# Prometheia MVP
+
+## Development
+
+```bash
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+In another terminal:
+```bash
+cd frontend && npm install && npm run dev
+```
+Open <http://localhost:5173> in your browser.

--- a/backend/graph.py
+++ b/backend/graph.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from typing import List, Tuple, Dict, Any
+from sqlmodel import Session
+from .models import Node, Edge
+
+Diff = Tuple[int, Dict[str, Any], Dict[str, Any]]
+
+
+def add_node(session: Session, label: str, ntype: str = "Fact", distribution: str = "") -> Node:
+    node = Node(label=label, ntype=ntype, distribution=distribution)
+    session.add(node)
+    session.commit()
+    session.refresh(node)
+    return node
+
+
+def add_edge(session: Session, source_id: int, target_id: int) -> Edge:
+    edge = Edge(source_id=source_id, target_id=target_id)
+    session.add(edge)
+    session.commit()
+    session.refresh(edge)
+    return edge
+
+
+def delete_node(session: Session, node_id: int) -> None:
+    node = session.get(Node, node_id)
+    if node:
+        session.delete(node)
+        session.commit()
+
+
+def ripple_update(session: Session, changed_node_id: int) -> List[Diff]:
+    """Update timestamp of downstream nodes and return diffs."""
+    diffs: List[Diff] = []
+    query = (
+        "WITH RECURSIVE desc(id, depth) AS ("
+        " SELECT :start_id, 0"
+        " UNION ALL"
+        " SELECT edge.source_id, depth + 1"
+        " FROM edge JOIN desc ON edge.target_id = desc.id"
+        ") SELECT id, depth FROM desc ORDER BY depth;"
+    )
+    results = session.exec(query, {"start_id": changed_node_id}).all()
+    for node_id, depth in results:
+        node = session.get(Node, node_id)
+        if not node:
+            continue
+        old = node.dict()
+        if depth > 0:  # propagate to downstream nodes only
+            node.updated = datetime.utcnow()
+            session.add(node)
+        session.commit()
+        session.refresh(node)
+        diffs.append((node_id, old, node.dict()))
+    return diffs

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,142 @@
+import json
+from datetime import datetime
+from typing import List
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+from sqlmodel import SQLModel, Session, create_engine, select
+
+from .models import Node, Edge
+from .graph import add_node, add_edge, delete_node, ripple_update
+
+DATABASE_URL = "sqlite:///backend/db.sqlite"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class ConnectionManager:
+    def __init__(self):
+        self.active: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active.append(websocket)
+
+    def disconnect(self, websocket: WebSocket):
+        if websocket in self.active:
+            self.active.remove(websocket)
+
+    async def broadcast(self, message: str):
+        for ws in list(self.active):
+            try:
+                await ws.send_text(message)
+            except WebSocketDisconnect:
+                self.disconnect(ws)
+
+manager = ConnectionManager()
+
+@app.on_event("startup")
+def on_startup():
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        count = session.exec(select(Node)).first()
+        if count is None:
+            n1 = add_node(session, "Example A")
+            n2 = add_node(session, "Example B")
+            n3 = add_node(session, "Example C")
+            add_edge(session, n2.id, n1.id)
+            add_edge(session, n3.id, n2.id)
+
+# REST endpoints
+
+@app.get("/nodes")
+def get_nodes():
+    with Session(engine) as session:
+        return session.exec(select(Node)).all()
+
+@app.get("/edges")
+def get_edges():
+    with Session(engine) as session:
+        return session.exec(select(Edge)).all()
+
+@app.post("/nodes")
+def create_node(node: Node):
+    with Session(engine) as session:
+        created = add_node(session, node.label, node.ntype, node.distribution)
+        diffs = ripple_update(session, created.id)
+    message = json.dumps(diffs)
+    import asyncio
+    asyncio.create_task(manager.broadcast(message))
+    return created
+
+@app.put("/nodes/{node_id}")
+def update_node(node_id: int, data: Node):
+    with Session(engine) as session:
+        node = session.get(Node, node_id)
+        if not node:
+            return {"error": "not found"}
+        old = node.dict()
+        node.label = data.label
+        node.ntype = data.ntype
+        node.distribution = data.distribution
+        node.updated = datetime.utcnow()
+        session.add(node)
+        session.commit()
+        session.refresh(node)
+        diffs = [(node_id, old, node.dict())]
+        diffs += ripple_update(session, node_id)
+    message = json.dumps(diffs)
+    import asyncio
+    asyncio.create_task(manager.broadcast(message))
+    return node
+
+@app.delete("/nodes/{node_id}")
+def delete_node_route(node_id: int):
+    with Session(engine) as session:
+        delete_node(session, node_id)
+        diffs = ripple_update(session, node_id)
+    message = json.dumps(diffs)
+    import asyncio
+    asyncio.create_task(manager.broadcast(message))
+    return {"status": "ok"}
+
+@app.post("/edges")
+def create_edge(edge: Edge):
+    with Session(engine) as session:
+        created = add_edge(session, edge.source_id, edge.target_id)
+        diffs = ripple_update(session, edge.source_id)
+    message = json.dumps(diffs)
+    import asyncio
+    asyncio.create_task(manager.broadcast(message))
+    return created
+
+@app.delete("/edges/{edge_id}")
+def delete_edge(edge_id: int):
+    with Session(engine) as session:
+        edge = session.get(Edge, edge_id)
+        if edge:
+            source = edge.source_id
+            session.delete(edge)
+            session.commit()
+            diffs = ripple_update(session, source)
+        else:
+            diffs = []
+    message = json.dumps(diffs)
+    import asyncio
+    asyncio.create_task(manager.broadcast(message))
+    return {"status": "ok"}
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await manager.connect(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from typing import Optional
+from sqlmodel import SQLModel, Field
+
+class Node(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    label: str
+    ntype: str = Field(index=True)
+    distribution: str = ""
+    created: datetime = Field(default_factory=datetime.utcnow)
+    updated: datetime = Field(default_factory=datetime.utcnow, sa_column_kwargs={"onupdate": datetime.utcnow})
+
+class Edge(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    source_id: int = Field(foreign_key="node.id")
+    target_id: int = Field(foreign_key="node.id")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prometheia</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react'
+import GraphView from './GraphView'
+import NodeEditor from './NodeEditor'
+import { fetchNodes, fetchEdges, addNode, deleteNodeApi } from './api'
+
+interface NodeData {
+  id: number
+  label: string
+  ntype: string
+  distribution: string
+}
+
+interface EdgeData {
+  id: number
+  source_id: number
+  target_id: number
+}
+
+const App: React.FC = () => {
+  const [nodes, setNodes] = useState<NodeData[]>([])
+  const [edges, setEdges] = useState<EdgeData[]>([])
+  const [selected, setSelected] = useState<NodeData | null>(null)
+
+  useEffect(() => {
+    load()
+    const ws = new WebSocket(`ws://${location.host}/ws`)
+    ws.onmessage = (ev) => {
+      const diffs = JSON.parse(ev.data)
+      for (const [id] of diffs) {
+        const el = cyRef?.getElementById(String(id))
+        if (el) {
+          el.flash()
+        }
+      }
+    }
+  }, [])
+
+  const [cyRef, setCyRef] = useState<any>(null)
+
+  const load = async () => {
+    setNodes(await fetchNodes())
+    setEdges(await fetchEdges())
+  }
+
+  const addNew = async () => {
+    await addNode({ label: 'New Node', ntype: 'Fact', distribution: '' })
+    await load()
+  }
+
+  const deleteSelected = async () => {
+    if (selected) {
+      await deleteNodeApi(selected.id)
+      setSelected(null)
+      await load()
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <div style={{ position: 'absolute', padding: 10 }}>
+        <button onClick={addNew}>Add node</button>
+        {selected && <button onClick={deleteSelected}>Delete</button>}
+      </div>
+      <div style={{ flex: 1 }}>
+        <GraphView nodes={nodes} edges={edges} onSelect={setSelected} setCyRef={setCyRef} />
+      </div>
+      <NodeEditor node={selected} onSaved={load} />
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/GraphView.tsx
+++ b/frontend/src/GraphView.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef } from 'react'
+import cytoscape from 'cytoscape'
+import edgehandles from 'cytoscape-edgehandles'
+import { createEdge, deleteEdgeApi } from './api'
+
+cytoscape.use(edgehandles)
+
+interface Props {
+  nodes: any[]
+  edges: any[]
+  onSelect: (n: any | null) => void
+  setCyRef: (cy: any) => void
+}
+
+const GraphView: React.FC<Props> = ({ nodes, edges, onSelect, setCyRef }) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const cyRef = useRef<any>(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    if (!cyRef.current) {
+      cyRef.current = cytoscape({
+        container: containerRef.current,
+        style: [
+          { selector: 'node', style: { 'background-color': '#ccc', label: 'data(label)' } },
+          { selector: 'edge', style: { width: 2, 'line-color': '#888', 'target-arrow-shape': 'triangle', 'target-arrow-color': '#888' } },
+          { selector: '.flash', style: { 'background-color': 'yellow' } }
+        ]
+      })
+      const eh = cyRef.current.edgehandles()
+      cyRef.current.on('ehcomplete', async (_: any, source: any, target: any, edge: any) => {
+        await createEdge(Number(source.id()), Number(target.id()))
+      })
+      cyRef.current.on('cxttap', 'edge', async (e: any) => {
+        await deleteEdgeApi(Number(e.target.id()))
+      })
+      cyRef.current.on('select', 'node', (e: any) => onSelect(e.target.data()))
+      cyRef.current.on('unselect', 'node', () => onSelect(null))
+      cyRef.current.nodes().forEach(n => {
+        ;(n as any).flash = () => {
+          n.addClass('flash')
+          setTimeout(() => n.removeClass('flash'), 1000)
+        }
+      })
+      setCyRef(cyRef.current)
+    }
+    cyRef.current.json({ elements: { nodes: nodes.map(n => ({ data: { ...n, id: String(n.id) } })), edges: edges.map(e => ({ data: { id: String(e.id), source: String(e.source_id), target: String(e.target_id) } })) } })
+    cyRef.current.nodes().forEach(n => {
+      if (!(n as any).flash) {
+        ;(n as any).flash = () => {
+          n.addClass('flash')
+          setTimeout(() => n.removeClass('flash'), 1000)
+        }
+      }
+    })
+  }, [nodes, edges])
+
+  return <div style={{ width: '100%', height: '100%' }} ref={containerRef} />
+}
+
+export default GraphView

--- a/frontend/src/NodeEditor.tsx
+++ b/frontend/src/NodeEditor.tsx
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react'
+import { updateNode, deleteNodeApi } from './api'
+
+interface Props {
+  node: any | null
+  onSaved: () => void
+}
+
+const NodeEditor: React.FC<Props> = ({ node, onSaved }) => {
+  const [label, setLabel] = useState('')
+  const [ntype, setNtype] = useState('Fact')
+  const [distribution, setDistribution] = useState('')
+
+  useEffect(() => {
+    if (node) {
+      setLabel(node.label)
+      setNtype(node.ntype)
+      setDistribution(node.distribution)
+    }
+  }, [node])
+
+  if (!node) return <div style={{ width: 300, padding: 10 }}>Select a node</div>
+
+  const save = async () => {
+    await updateNode(node.id, { label, ntype, distribution })
+    onSaved()
+  }
+
+  const del = async () => {
+    await deleteNodeApi(node.id)
+    onSaved()
+  }
+
+  return (
+    <div style={{ width: 300, padding: 10 }}>
+      <div>
+        <label>Label</label>
+        <input value={label} onChange={e => setLabel(e.target.value)} />
+      </div>
+      <div>
+        <label>Type</label>
+        <select value={ntype} onChange={e => setNtype(e.target.value)}>
+          <option value="Fact">Fact</option>
+          <option value="Constraint">Constraint</option>
+          <option value="Prompt">Prompt</option>
+        </select>
+      </div>
+      <div>
+        <label>Distribution</label>
+        <input value={distribution} onChange={e => setDistribution(e.target.value)} />
+      </div>
+      <button onClick={save}>Save</button>
+      <button onClick={del}>Delete</button>
+    </div>
+  )
+}
+
+export default NodeEditor

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,48 @@
+export interface NodePayload {
+  label: string
+  ntype: string
+  distribution: string
+}
+
+export const fetchNodes = async () => {
+  const res = await fetch('/nodes')
+  return res.json()
+}
+
+export const fetchEdges = async () => {
+  const res = await fetch('/edges')
+  return res.json()
+}
+
+export const updateNode = async (id: number, data: NodePayload) => {
+  await fetch(`/nodes/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  })
+}
+
+export const addNode = async (data: NodePayload) => {
+  const res = await fetch('/nodes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  })
+  return res.json()
+}
+
+export const deleteNodeApi = async (id: number) => {
+  await fetch(`/nodes/${id}`, { method: 'DELETE' })
+}
+
+export const createEdge = async (source_id: number, target_id: number) => {
+  await fetch('/edges', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source_id, target_id })
+  })
+}
+
+export const deleteEdgeApi = async (id: number) => {
+  await fetch(`/edges/${id}`, { method: 'DELETE' })
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "prometheia-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "cytoscape": "^3.26.0",
+    "cytoscape-edgehandles": "^4.0.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+sqlmodel
+aiosqlite

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["frontend/src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  root: 'frontend',
+  server: {
+    proxy: {
+      '/': 'http://localhost:8000'
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- set up FastAPI backend with websocket broadcasting and SQLite models
- add recursive graph helper for ripple updates
- implement React/Vite frontend with Cytoscape graph editor
- support node/edge CRUD with live update flashes
- provide development instructions and config files

## Testing
- `python3 -m py_compile backend/*.py`
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846a2234bcc832cb3910c0ad533c935